### PR TITLE
Disable in test files, fix variable/constant docs in parenthesized blocks

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,10 +10,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 )
 
 var (
-	commentBase = "\n// %s "
+	commentBase = "// %s "
 	fset        = token.NewFileSet()
 	defaultMode = os.FileMode(0644)
 )
@@ -67,6 +68,11 @@ func gocmtRun() int {
 }
 
 func processFile(filename, template string, inPlace bool) error {
+	// skip test files
+	if strings.HasSuffix(filename, "_test.go"){
+		return nil
+	}
+
 	f, err := os.Open(filename)
 	if err != nil {
 		return err

--- a/main.go
+++ b/main.go
@@ -16,7 +16,8 @@ import (
 var (
 	// ensure that the comment starts on a newline (without the \n, sometimes it starts on the previous }
 	commentBase = "\n// %s "
-	commentIndentedBase = "// %s "  // if it's in an indented block, this makes sure that the indentation is correct
+	// if it's in an indented block, this makes sure that the indentation is correct
+	commentIndentedBase = "// %s "
 	fset        = token.NewFileSet()
 	defaultMode = os.FileMode(0644)
 )

--- a/main.go
+++ b/main.go
@@ -14,7 +14,9 @@ import (
 )
 
 var (
-	commentBase = "// %s "
+	// ensure that the comment starts on a newline (without the \n, sometimes it starts on the previous }
+	commentBase = "\n// %s "
+	commentIndentedBase = "// %s "  // if it's in an indented block, this makes sure that the indentation is correct
 	fset        = token.NewFileSet()
 	defaultMode = os.FileMode(0644)
 )

--- a/parse.go
+++ b/parse.go
@@ -112,7 +112,7 @@ func addValueSpecComment(gd *ast.GenDecl, vs *ast.ValueSpec, commentTemplate str
 
 func addParenValueSpecComment( vs *ast.ValueSpec, commentTemplate string) {
 	if vs.Doc == nil || strings.TrimSpace(vs.Doc.Text()) == vs.Names[0].Name {
-		// commentTemplate = strings.Replace(commentTemplate, commentBase, commentIndentedBase, 1)
+		commentTemplate = strings.Replace(commentTemplate, commentBase, commentIndentedBase, 1)
 		text := fmt.Sprintf(commentTemplate, vs.Names[0].Name)
 		pos := vs.Pos() - token.Pos(1)
 		vs.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}

--- a/parse.go
+++ b/parse.go
@@ -68,7 +68,6 @@ func parseFile(fset *token.FileSet, path, template string) (*ast.File, error) {
 					continue
 				}
 
-
 			case token.TYPE:
 				ts := gd.Specs[0].(*ast.TypeSpec)
 				if !ts.Name.IsExported() {

--- a/parse.go
+++ b/parse.go
@@ -49,11 +49,26 @@ func parseFile(fset *token.FileSet, path, template string) (*ast.File, error) {
 
 			switch gd.Tok {
 			case token.CONST, token.VAR:
-				vs := gd.Specs[0].(*ast.ValueSpec)
-				if !vs.Names[0].IsExported() {
+				if gd.Lparen == token.NoPos && gd.Rparen == token.NoPos{
+					vs := gd.Specs[0].(*ast.ValueSpec)
+					if !vs.Names[0].IsExported() {
+						continue
+					}
+					addValueSpecComment(gd, vs, commentTemplate)
+				} else {
+					// if there's a () add comment for each sub entry
+					for _, spec := range gd.Specs{
+						vs := spec.(*ast.ValueSpec)
+						if !vs.Names[0].IsExported() {
+							continue
+						}
+						addParenValueSpecComment( vs, commentTemplate)
+						cmap[vs] = []*ast.CommentGroup{vs.Doc}
+					}
 					continue
 				}
-				addValueSpecComment(gd, vs, commentTemplate)
+
+
 			case token.TYPE:
 				ts := gd.Specs[0].(*ast.TypeSpec)
 				if !ts.Name.IsExported() {
@@ -91,6 +106,16 @@ func addValueSpecComment(gd *ast.GenDecl, vs *ast.ValueSpec, commentTemplate str
 		text := fmt.Sprintf(commentTemplate, vs.Names[0].Name)
 		pos := gd.Pos() - token.Pos(1)
 		gd.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
+	}
+}
+
+
+func addParenValueSpecComment( vs *ast.ValueSpec, commentTemplate string) {
+	if vs.Doc == nil || strings.TrimSpace(vs.Doc.Text()) == vs.Names[0].Name {
+		// commentTemplate = strings.Replace(commentTemplate, commentBase, commentIndentedBase, 1)
+		text := fmt.Sprintf(commentTemplate, vs.Names[0].Name)
+		pos := vs.Pos() - token.Pos(1)
+		vs.Doc = &ast.CommentGroup{List: []*ast.Comment{{Slash: pos, Text: text}}}
 	}
 }
 

--- a/parse_test.go
+++ b/parse_test.go
@@ -11,6 +11,7 @@ func Test_parseFile(t *testing.T) {
 		wantErr bool
 	}{
 		{"testdata/main.go", false},
+		{"testdata/parenthesis.go", false},
 		{"testdata/invalid_file.go", true},
 	}
 

--- a/testdata/parenthesis.go
+++ b/testdata/parenthesis.go
@@ -1,0 +1,18 @@
+package p
+
+type Summon string
+
+const (
+	DarkOmega Summon = "celeste"
+	// LightOmega best summon
+	LightOmega Summon = "luminineria"
+	// WindOmega
+	WindOmega Summon = "tiamat"
+)
+
+const FireUtility Summon = "the sun"
+
+const (
+	// Light best summon
+	Light Summon = "lucifer"
+)


### PR DESCRIPTION
the original doesn't work when variables are on this kind of block 
```
var (
    V string
    W string
)
```
as it'll put any comments on the top of the var block instead of the individual comments
